### PR TITLE
Fix payload file name and cleanup clear()

### DIFF
--- a/modules/salex_create.py
+++ b/modules/salex_create.py
@@ -35,7 +35,10 @@ def check_payload(payload):
         return False
 
 def create_payload(payload , payload_name, payload_host, payload_port):
-    file = open('paylaod.txt', 'w')
+    # The output filename was misspelled as 'paylaod.txt', which results in an
+    # incorrectly named file being created.  Use the correct spelling so the
+    # generated payload is stored in 'payload.txt'.
+    file = open('payload.txt', 'w')
     file.write(f"{payload}")
     file.write(f"\n{payload_name}")
     file.write(f"\n{payload_host}")

--- a/modules/salex_functions.py
+++ b/modules/salex_functions.py
@@ -40,7 +40,8 @@ def machine_os():
         print("Failed To Get The Machine Os")
 
 def clear():
+    """Clear the terminal screen regardless of platform."""
     if machine_os() == "Windows":
-        clear = os.system("cls")
+        os.system("cls")
     else:
-        clear = os.system("clear")
+        os.system("clear")

--- a/payloads/mac/mosu.py
+++ b/payloads/mac/mosu.py
@@ -21,7 +21,8 @@ def check_payload(payload):
         return False
 
 def create_payload(payload , payload_name, payload_host, payload_port):
-    file = open('paylaod.txt', 'w')
+    # Use the correct filename for the generated payload.
+    file = open('payload.txt', 'w')
     file.write(f"{payload}")
     file.write(f"\n{payload_name}")
     file.write(f"\n{payload_host}")

--- a/payloads/windows/whoami_create.py
+++ b/payloads/windows/whoami_create.py
@@ -21,7 +21,9 @@ def check_payload(payload):
         return False
 
 def create_payload(payload , payload_name, payload_host, payload_port):
-    file = open('paylaod.txt', 'w')
+    # Correct the misspelled output file name so generated payloads are
+    # consistently written to 'payload.txt'.
+    file = open('payload.txt', 'w')
     file.write(f"{payload}")
     file.write(f"\n{payload_name}")
     file.write(f"\n{payload_host}")


### PR DESCRIPTION
## Summary
- correct misspelled payload filename in all creation routines
- avoid overwriting `clear` function name in `salex_functions`

## Testing
- `python -m py_compile $(find . -name '*.py' -print)`